### PR TITLE
chore: run npm fix on `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.3.0",
   "license": "MIT",
   "description": "Generate web bundles with Nuxt",
-  "repository": "danielroe/nuxt-web-bundle",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/danielroe/nuxt-web-bundle.git"
+  },
   "keywords": [
     "nuxt",
     "module",


### PR DESCRIPTION
Publishing a package with the latest version of npm gives rise to the following error:

```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository" was changed from a string to an object
npm WARN publish "repository.url" was normalized to "git+https://github.com/<repo>.git"
```

This PR (it isn't much, I know!) runs the command ...

See https://docs.npmjs.com/cli/v10/configuring-npm/package-json and specifically https://github.com/npm/cli/issues/7299#issuecomment-2010009355.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the repository information in the package configuration to enhance project tracking and version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->