### PR TITLE
chore: update link to downloads count badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Published under the [MIT License](./LICENCE).
 [npm-version-href]: https://npmjs.com/package/nuxt-web-bundle
 [npm-downloads-src]: https://img.shields.io/npm/dm/nuxt-web-bundle?style=flat-square
 [npm-downloads-href]: https://npm.chart.dev/nuxt-web-bundle
-[github-actions-src]: https://img.shields.io/github/workflow/status/danielroe/nuxt-web-bundle/ci/main?style=flat-square
-[github-actions-href]: https://github.com/danielroe/nuxt-web-bundle/actions?query=workflow%3Aci
+[github-actions-src]: https://img.shields.io/github/actions/workflow/status/danielroe/nuxt-web-bundle/ci.yml?branch=main&style=flat-square
+[github-actions-href]: https://github.com/danielroe/nuxt-web-bundle/actions/workflows/ci.yml
 [codecov-src]: https://img.shields.io/codecov/c/gh/danielroe/nuxt-web-bundle/main?style=flat-square
 [codecov-href]: https://codecov.io/gh/danielroe/nuxt-web-bundle


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated GitHub Actions badge links in the README file to reflect the new format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->