### PR TITLE
chore: replace `latest` ranges with caret ranges

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -6,7 +6,7 @@
     "dev": "nuxi build && echo 'Download bundle.wbn and open locally to test.' && npx serve dist"
   },
   "devDependencies": {
-    "nuxt": "latest",
+    "nuxt": "^4.5.1",
     "nuxt-web-bundle": "latest"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ importers:
   playground:
     devDependencies:
       nuxt:
-        specifier: latest
+        specifier: ^4.5.1
         version: 4.5.1(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.0))(@oxc-project/types@0.142.0)(@parcel/watcher@2.5.6)(@types/node@24.12.4)(@vue/compiler-sfc@3.5.41)(cac@6.7.14)(db0@0.3.4)(esbuild@0.28.0)(eslint@10.7.0(jiti@2.7.0))(ioredis@5.10.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.80.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0))(rollup-plugin-visualizer@7.0.1(rolldown@1.2.2)(rollup@4.60.4))(rollup@4.60.4)(terser@5.44.0)(typescript@5.6.3)(vite@8.2.0(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.44.0)(yaml@2.9.0))(yaml@2.9.0)
       nuxt-web-bundle:
         specifier: link:..


### PR DESCRIPTION
`latest` is a curse and can easily drift, or change wildly on lockfile regeneration